### PR TITLE
Document JDK requirement for Android builds

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 ## Ease your stress and anxiety
 
 ### Devel notes
+- Install JDK 11 (LTS) and ensure `JAVA_HOME` points to it so Android builds use the expected toolchain.
 - clone repo
 - `yarn install`
 - `yarn run


### PR DESCRIPTION
## Summary
- document the JDK 11 requirement in the README so developers configure JAVA_HOME instead of relying on a container-specific Gradle override
- ensure Gradle uses the JAVA_HOME/Android Studio runtime by not pinning org.gradle.java.home

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca94126b3c83289014bad8912adeca