### PR TITLE
Fix Android Gradle daemon launch on modern JDKs

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,12 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+# The MaxPermSize option was removed in Java 8+. Keeping it in the arguments
+# prevents the Gradle daemon from starting when using modern JDK versions.
+#
+# React Native Android builds target JDK 11, so we trim the unsupported
+# parameter while preserving the previous memory settings.
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.


### PR DESCRIPTION
## Summary
- remove the deprecated `-XX:MaxPermSize` JVM argument so the Gradle daemon can start on Java 11+
- document the change in gradle.properties to clarify the supported JDK level and preserve the previous memory tuning

## Testing
- `JAVA_HOME=/root/.local/share/mise/installs/java/11 PATH=/root/.local/share/mise/installs/java/11/bin:$PATH ./gradlew assembleDebug` *(fails: missing npm dependencies because registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cab522d014832881185e760d5f8ec5